### PR TITLE
Try to fix strange installation problem

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,3 +17,4 @@ RoxygenNote: 7.3.1
 Suggests: 
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
+


### PR DESCRIPTION
devtools::install_github("statisticsnorway/ssb-sdclonn") results in: "Line starting 'Config/testthat/edit ...' is malformed!"

However, no problem when installed from identical branch.

Now, try another line break at the end to see what happens.